### PR TITLE
fix build error under 3.10

### DIFF
--- a/LAppModelWrapper.cpp
+++ b/LAppModelWrapper.cpp
@@ -19,6 +19,10 @@
 #include <Windows.h>
 #endif
 
+#ifndef Py_IsNone
+#define Py_IsNone(o) (o == Py_None)
+#endif
+
 static LAppAllocator _cubismAllocator;
 static Csm::CubismFramework::Option _cubismOption;
 


### PR DESCRIPTION
添加了3.8及3.9版本构建错误的简单修复。

另外，能否在自动构建脚本中加入3.8及3.9版本的二进制库构建？