### PR TITLE
Fix std::min / std::max with initializer_list<T> as an argument on GCC/CLang

### DIFF
--- a/Main/src/fine-grained/Model.cpp
+++ b/Main/src/fine-grained/Model.cpp
@@ -15,6 +15,7 @@
 #include <filesystem>
 #include <functional>
 #include <unordered_set>
+#include <algorithm>
 
 using namespace Live2D::Cubism::Framework;
 using namespace LAppDefine;


### PR DESCRIPTION
Currently the code in `Main/src/fine-grained/Model.cpp` uses `std::min` and `std::max` with initializer lists as follows:

https://github.com/Arkueid/live2d-py/blob/main/Main/src/fine-grained/Model.cpp#L761

While this is permitted since C++11, up until C++23 this requires including `<algorithm>` header.
Otherwise under Linux GCC / CLang refuse to accept such code, thus `pip install live2d-py` fails.
(MSVC++ historically treats both `std::min` and `std::max` a bit differently compared to how they are declared in C++ standard, so the code might have been working there.)

You can also set C++ standard to 23 in `CMakeLists.txt` but this will lead to a bunch of other errors, so this PR is a simplest fix possible.